### PR TITLE
A better story for canary jobs (yellow CI)

### DIFF
--- a/azure/cargo-check.yml
+++ b/azure/cargo-check.yml
@@ -2,13 +2,20 @@ parameters:
   rust: stable
   benches: false
   setup: []
+  err_on_warn: false
 
 jobs:
 - job: ${{ parameters.name }}
   ${{ if eq(parameters.rust, 'stable') }}:
-    displayName: cargo check
+    ${{ if eq(parameters.err_on_warn, 'true') }}:
+      displayName: "env RUSTFLAGS=-Dwarnings cargo check"
+    ${{ if ne(parameters.err_on_warn, 'true') }}:
+      displayName: cargo check
   ${{ if ne(parameters.rust, 'stable') }}:
-    displayName: cargo +${{ parameters.rust }} check
+    ${{ if eq(parameters.err_on_warn, 'true') }}:
+      displayName: "env RUSTFLAGS=-Dwarnings cargo +${{ parameters.rust }} check"
+    ${{ if ne(parameters.err_on_warn, 'true') }}:
+      displayName: cargo +${{ parameters.rust }} check
   pool:
     vmImage: ubuntu-16.04
   steps:
@@ -16,6 +23,9 @@ jobs:
     parameters:
       rust: ${{ parameters.rust }}
       setup: ${{ parameters.setup }}
+  - ${{ if eq(parameters.err_on_warn, 'true') }}:
+    - bash: echo "##vso[task.setvariable variable=RUSTFLAGS;]-Dwarnings"
+      displayName: "Enable warnings from rustc"
   - script: cargo check --all --bins --examples --tests
     displayName: Check compilation w/ default features
   - script: cargo check --all --bins --examples --tests --no-default-features

--- a/azure/cargo-check.yml
+++ b/azure/cargo-check.yml
@@ -3,6 +3,7 @@ parameters:
   benches: false
   setup: []
   err_on_warn: false
+  allow_fail: false
 
 jobs:
 - job: ${{ parameters.name }}
@@ -16,6 +17,7 @@ jobs:
       displayName: "cargo +${{ parameters.rust }} check -Dwarnings"
     ${{ if ne(parameters.err_on_warn, 'true') }}:
       displayName: cargo +${{ parameters.rust }} check
+  continueOnError: ${{ parameters.allow_fail }}
   pool:
     vmImage: ubuntu-16.04
   steps:

--- a/azure/cargo-check.yml
+++ b/azure/cargo-check.yml
@@ -8,12 +8,12 @@ jobs:
 - job: ${{ parameters.name }}
   ${{ if eq(parameters.rust, 'stable') }}:
     ${{ if eq(parameters.err_on_warn, 'true') }}:
-      displayName: "env RUSTFLAGS=-Dwarnings cargo check"
+      displayName: "cargo check -Dwarnings"
     ${{ if ne(parameters.err_on_warn, 'true') }}:
       displayName: cargo check
   ${{ if ne(parameters.rust, 'stable') }}:
     ${{ if eq(parameters.err_on_warn, 'true') }}:
-      displayName: "env RUSTFLAGS=-Dwarnings cargo +${{ parameters.rust }} check"
+      displayName: "cargo +${{ parameters.rust }} check -Dwarnings"
     ${{ if ne(parameters.err_on_warn, 'true') }}:
       displayName: cargo +${{ parameters.rust }} check
   pool:

--- a/azure/cargo-clippy.yml
+++ b/azure/cargo-clippy.yml
@@ -2,13 +2,20 @@ parameters:
   rust: stable
   allow_fail: false
   setup: []
+  fail_all: false
 
 jobs:
 - job: ${{ parameters.name }}
   ${{ if eq(parameters.rust, 'stable') }}:
-    displayName: cargo clippy
+    ${{ if eq(parameters.fail_all, 'true') }}:
+      displayName: cargo clippy -- -D warnings
+    ${{ if ne(parameters.fail_all, 'true') }}:
+      displayName: cargo clippy
   ${{ if ne(parameters.rust, 'stable') }}:
-    displayName: cargo +${{ parameters.rust }} clippy
+    ${{ if eq(parameters.fail_all, 'true') }}:
+      displayName: cargo +${{ parameters.rust }} clippy -- -D warnings
+    ${{ if ne(parameters.fail_all, 'true') }}:
+      displayName: cargo +${{ parameters.rust }} clippy
   continueOnError: ${{ parameters.allow_fail }}
   pool:
     vmImage: ubuntu-16.04
@@ -19,5 +26,9 @@ jobs:
         setup: ${{ parameters.setup }}
         components:
           - clippy
-    - script: cargo clippy --all 
-      displayName: Run clippy
+    - ${{ if eq(parameters.fail_all, 'true') }}:
+      - script: cargo clippy --all -- -D warnings
+        displayName: Run strict clippy
+    - ${{ if ne(parameters.fail_all, 'true') }}:
+      - script: cargo clippy --all
+        displayName: Run strict clippy

--- a/azure/cargo-clippy.yml
+++ b/azure/cargo-clippy.yml
@@ -20,4 +20,4 @@ jobs:
         components:
           - clippy
     - script: cargo clippy --all
-      displayName: Run strict clippy
+      displayName: Run clippy

--- a/azure/cargo-clippy.yml
+++ b/azure/cargo-clippy.yml
@@ -2,20 +2,13 @@ parameters:
   rust: stable
   allow_fail: false
   setup: []
-  fail_all: false
 
 jobs:
 - job: ${{ parameters.name }}
   ${{ if eq(parameters.rust, 'stable') }}:
-    ${{ if eq(parameters.fail_all, 'true') }}:
-      displayName: cargo clippy -- -D warnings
-    ${{ if ne(parameters.fail_all, 'true') }}:
-      displayName: cargo clippy
+    displayName: cargo clippy
   ${{ if ne(parameters.rust, 'stable') }}:
-    ${{ if eq(parameters.fail_all, 'true') }}:
-      displayName: cargo +${{ parameters.rust }} clippy -- -D warnings
-    ${{ if ne(parameters.fail_all, 'true') }}:
-      displayName: cargo +${{ parameters.rust }} clippy
+    displayName: cargo +${{ parameters.rust }} clippy
   continueOnError: ${{ parameters.allow_fail }}
   pool:
     vmImage: ubuntu-16.04
@@ -26,9 +19,5 @@ jobs:
         setup: ${{ parameters.setup }}
         components:
           - clippy
-    - ${{ if eq(parameters.fail_all, 'true') }}:
-      - script: cargo clippy --all -- -D warnings
-        displayName: Run strict clippy
-    - ${{ if ne(parameters.fail_all, 'true') }}:
-      - script: cargo clippy --all
-        displayName: Run strict clippy
+    - script: cargo clippy --all
+      displayName: Run strict clippy

--- a/azure/stages.yml
+++ b/azure/stages.yml
@@ -4,6 +4,7 @@ parameters:
   prefix: ''
   envs: {}
   setup: []
+  smoketests: true
 
 stages:
  # the format here is so that we can have _two_ instances of this whole
@@ -46,6 +47,7 @@ stages:
        parameters:
          envs: ${{ parameters.envs }}
          setup: ${{ parameters.setup }}
+         smoketests: ${{ parameters.smoketests }}
  - stage: ${{ format('{0}style', parameters.prefix) }}
    ${{ if ne(parameters.prefix, '') }}:
      displayName: ${{ format('Style linting ({0})', parameters.prefix) }}
@@ -56,6 +58,7 @@ stages:
      - template: style.yml
        parameters:
          setup: ${{ parameters.setup }}
+         smoketests: ${{ parameters.smoketests }}
  - ${{ if ne('', parameters.codecov_token) }}:
     - stage: ${{ format('{0}coverage', parameters.prefix) }}
       ${{ if ne(parameters.prefix, '') }}:

--- a/azure/stages.yml
+++ b/azure/stages.yml
@@ -4,7 +4,7 @@ parameters:
   prefix: ''
   envs: {}
   setup: []
-  smoketests: true
+  canaries: true
 
 stages:
  # the format here is so that we can have _two_ instances of this whole
@@ -47,7 +47,7 @@ stages:
        parameters:
          envs: ${{ parameters.envs }}
          setup: ${{ parameters.setup }}
-         smoketests: ${{ parameters.smoketests }}
+         canaries: ${{ parameters.canaries }}
  - stage: ${{ format('{0}style', parameters.prefix) }}
    ${{ if ne(parameters.prefix, '') }}:
      displayName: ${{ format('Style linting ({0})', parameters.prefix) }}
@@ -58,7 +58,7 @@ stages:
      - template: style.yml
        parameters:
          setup: ${{ parameters.setup }}
-         smoketests: ${{ parameters.smoketests }}
+         canaries: ${{ parameters.canaries }}
  - ${{ if ne('', parameters.codecov_token) }}:
     - stage: ${{ format('{0}coverage', parameters.prefix) }}
       ${{ if ne(parameters.prefix, '') }}:

--- a/azure/style.yml
+++ b/azure/style.yml
@@ -17,10 +17,10 @@ jobs:
       name: clippy
       setup: ${{ parameters.setup }}
   - ${{ if eq(parameters.smoketests, 'true') }}:
-    - template: cargo-clippy.yml
+    - template: cargo-check.yml
       parameters:
-        name: clippy_nowarnings
-        fail_all: true
+        name: warning_free
+        err_on_warn: true
         allow_fail: true
   - ${{ if eq(parameters.smoketests, 'true') }}:
     - template: cargo-clippy.yml

--- a/azure/style.yml
+++ b/azure/style.yml
@@ -1,27 +1,31 @@
 parameters:
   setup: []
+  smoketests: true
 
 jobs:
   - template: rustfmt.yml
     parameters:
       name: rustfmt
-  - template: rustfmt.yml
-    parameters:
-      name: rustfmt_beta
-      rust: beta
-      allow_fail: true
+  - ${{ if eq(parameters.smoketests, 'true') }}:
+    - template: rustfmt.yml
+      parameters:
+        name: rustfmt_beta
+        rust: beta
+        allow_fail: true
   - template: cargo-clippy.yml
     parameters:
       name: clippy
       setup: ${{ parameters.setup }}
-  - template: cargo-clippy.yml
-    parameters:
-      name: clippy_nowarnings
-      fail_all: true
-      allow_fail: true
-  - template: cargo-clippy.yml
-    parameters:
-      name: clippy_beta
-      setup: ${{ parameters.setup }}
-      rust: beta
-      allow_fail: true
+  - ${{ if eq(parameters.smoketests, 'true') }}:
+    - template: cargo-clippy.yml
+      parameters:
+        name: clippy_nowarnings
+        fail_all: true
+        allow_fail: true
+  - ${{ if eq(parameters.smoketests, 'true') }}:
+    - template: cargo-clippy.yml
+      parameters:
+        name: clippy_beta
+        setup: ${{ parameters.setup }}
+        rust: beta
+        allow_fail: true

--- a/azure/style.yml
+++ b/azure/style.yml
@@ -20,6 +20,7 @@ jobs:
     - template: cargo-check.yml
       parameters:
         name: warning_free
+        setup: ${{ parameters.setup }}
         err_on_warn: true
         allow_fail: true
   - ${{ if eq(parameters.canaries, 'true') }}:

--- a/azure/style.yml
+++ b/azure/style.yml
@@ -16,6 +16,11 @@ jobs:
       setup: ${{ parameters.setup }}
   - template: cargo-clippy.yml
     parameters:
+      name: clippy_nowarnings
+      fail_all: true
+      allow_fail: true
+  - template: cargo-clippy.yml
+    parameters:
       name: clippy_beta
       setup: ${{ parameters.setup }}
       rust: beta

--- a/azure/style.yml
+++ b/azure/style.yml
@@ -23,7 +23,6 @@ jobs:
         setup: ${{ parameters.setup }}
         err_on_warn: true
         allow_fail: true
-  - ${{ if eq(parameters.canaries, 'true') }}:
     - template: cargo-clippy.yml
       parameters:
         name: clippy_beta

--- a/azure/style.yml
+++ b/azure/style.yml
@@ -1,12 +1,12 @@
 parameters:
   setup: []
-  smoketests: true
+  canaries: true
 
 jobs:
   - template: rustfmt.yml
     parameters:
       name: rustfmt
-  - ${{ if eq(parameters.smoketests, 'true') }}:
+  - ${{ if eq(parameters.canaries, 'true') }}:
     - template: rustfmt.yml
       parameters:
         name: rustfmt_beta
@@ -16,13 +16,13 @@ jobs:
     parameters:
       name: clippy
       setup: ${{ parameters.setup }}
-  - ${{ if eq(parameters.smoketests, 'true') }}:
+  - ${{ if eq(parameters.canaries, 'true') }}:
     - template: cargo-check.yml
       parameters:
         name: warning_free
         err_on_warn: true
         allow_fail: true
-  - ${{ if eq(parameters.smoketests, 'true') }}:
+  - ${{ if eq(parameters.canaries, 'true') }}:
     - template: cargo-clippy.yml
       parameters:
         name: clippy_beta

--- a/azure/tests.yml
+++ b/azure/tests.yml
@@ -1,6 +1,7 @@
 parameters:
   envs: {}
   setup: []
+  smoketests: true
 
 jobs:
  - template: test.yml
@@ -15,10 +16,11 @@ jobs:
      rust: beta
      envs: ${{ parameters.envs }}
      setup: ${{ parameters.setup }}
- - template: test.yml
-   parameters:
-     name: cargo_test_nightly
-     rust: nightly
-     allow_fail: true
-     envs: ${{ parameters.envs }}
-     setup: ${{ parameters.setup }}
+ - ${{ if eq(parameters.smoketests, 'true') }}:
+   - template: test.yml
+     parameters:
+       name: cargo_test_nightly
+       rust: nightly
+       allow_fail: true
+       envs: ${{ parameters.envs }}
+       setup: ${{ parameters.setup }}

--- a/azure/tests.yml
+++ b/azure/tests.yml
@@ -1,7 +1,7 @@
 parameters:
   envs: {}
   setup: []
-  smoketests: true
+  canaries: true
 
 jobs:
  - template: test.yml
@@ -10,13 +10,15 @@ jobs:
      cross: true # also test on Windows and macOS
      envs: ${{ parameters.envs }}
      setup: ${{ parameters.setup }}
- - template: test.yml
-   parameters:
-     name: cargo_test_beta
-     rust: beta
-     envs: ${{ parameters.envs }}
-     setup: ${{ parameters.setup }}
- - ${{ if eq(parameters.smoketests, 'true') }}:
+ - ${{ if eq(parameters.canaries, 'true') }}:
+   - template: test.yml
+     parameters:
+       name: cargo_test_beta
+       rust: beta
+       allow_fail: true
+       envs: ${{ parameters.envs }}
+       setup: ${{ parameters.setup }}
+ - ${{ if eq(parameters.canaries, 'true') }}:
    - template: test.yml
      parameters:
        name: cargo_test_nightly


### PR DESCRIPTION
This PR does two things.

First, it adds a new smoke test to the mix: `cargo check -- -D warnings`, which will error on _any_ warning from `rustc`.

Second, it makes it easy to opt out of all canaries (basically anything that is `allow_fail`) by setting 
```yaml
parameters:
  canaries: false
```
This will currently disable:
 - rustfmt on beta
 - clippy on beta
 - the new `-D warnings` test
 - test on nightly

This parameter is intended for users that worry about long-running or highly parallel CI, yellow CI ("partially successful").