### PR TITLE
Add nightly-only stages.yml

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,6 +35,19 @@ stages:
        ENV_IS_SET: true
      setup:
        - script: touch src/setup.rs
+ # and on nightly-only stages
+ - template: azure/nightly-stages.yml
+   parameters:
+     benches: true
+     test_features: ci,opt_in
+     test_ignored: true
+     single_threaded: true
+     prefix: "nightly_"
+     check_all_features: false
+     envs:
+       ENV_IS_SET: true
+     setup:
+       - script: touch src/setup.rs
  # test binary-focused stages (no min rust version test)
  - template: azure/stages.yml
    parameters:

--- a/azure/nightly-stages.yml
+++ b/azure/nightly-stages.yml
@@ -1,0 +1,75 @@
+parameters:
+  benches: false
+  prefix: ''
+  envs: {}
+  setup: []
+  test_ignored: false
+  single_threaded: false
+  check_all_features: true
+  test_features: ''
+
+stages:
+ # the format here is so that we can have _two_ instances of this whole
+ # template in the upstream repository's testing setup, and give the stages
+ # unique names.
+ - stage: ${{ format('{0}check', parameters.prefix) }}
+   ${{ if ne(parameters.prefix, '') }}:
+     displayName: ${{ format('Compilation check ({0})', parameters.prefix) }}
+   ${{ if eq(parameters.prefix, '') }}:
+     displayName: Compilation check
+   dependsOn: []
+   jobs:
+     - template: cargo-check.yml
+       parameters:
+         name: cargo_check
+         benches: ${{ parameters.benches }}
+         setup: ${{ parameters.setup }}
+         all_features: ${{ parameters.check_all_features }}
+         rust: nightly
+ - stage: ${{ format('{0}test', parameters.prefix) }}
+   ${{ if ne(parameters.prefix, '') }}:
+     displayName: ${{ format('Test suite ({0})', parameters.prefix) }}
+   ${{ if eq(parameters.prefix, '') }}:
+     displayName: Test suite
+   dependsOn: ${{ format('{0}check', parameters.prefix) }}
+   jobs:
+     - template: test.yml
+       parameters:
+         name: cargo_test
+         rust: nightly
+         envs: ${{ parameters.envs }}
+         setup: ${{ parameters.setup }}
+         test_ignored: ${{ parameters.test_ignored }}
+         single_threaded: ${{ parameters.single_threaded }}
+         features: ${{ parameters.test_features }}
+ - stage: ${{ format('{0}style', parameters.prefix) }}
+   ${{ if ne(parameters.prefix, '') }}:
+     displayName: ${{ format('Style linting ({0})', parameters.prefix) }}
+   ${{ if eq(parameters.prefix, '') }}:
+     displayName: Style linting
+   dependsOn: ${{ format('{0}check', parameters.prefix) }}
+   jobs:
+     - template: rustfmt.yml
+       parameters:
+         name: rustfmt
+         rust: nightly
+     - template: cargo-clippy.yml
+       parameters:
+         name: clippy
+         setup: ${{ parameters.setup }}
+         rust: nightly
+ - ${{ if ne('', parameters.codecov_token) }}:
+    - stage: ${{ format('{0}coverage', parameters.prefix) }}
+      ${{ if ne(parameters.prefix, '') }}:
+        displayName: ${{ format('Code coverage ({0})', parameters.prefix) }}
+      ${{ if eq(parameters.prefix, '') }}:
+        displayName: Code coverage
+      dependsOn: ${{ format('{0}test', parameters.prefix) }}
+      jobs:
+        - template: coverage.yml
+          parameters:
+            codecov_token: ${{ parameters.codecov_token }}
+            envs: ${{ parameters.envs }}
+            setup: ${{ parameters.setup }}
+            nightly: true
+            features: ${{ parameters.test_features }}

--- a/azure/nightly-stages.yml
+++ b/azure/nightly-stages.yml
@@ -53,11 +53,12 @@ stages:
        parameters:
          name: rustfmt
          rust: nightly
-     - template: cargo-clippy.yml
-       parameters:
-         name: clippy
-         setup: ${{ parameters.setup }}
-         rust: nightly
+   # disabled until we get https://github.com/rust-lang/rustup.rs/issues/2005
+   # - template: cargo-clippy.yml
+   #   parameters:
+   #     name: clippy
+   #     setup: ${{ parameters.setup }}
+   #     rust: nightly
  - ${{ if ne('', parameters.codecov_token) }}:
     - stage: ${{ format('{0}coverage', parameters.prefix) }}
       ${{ if ne(parameters.prefix, '') }}:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -31,6 +31,8 @@ you would give that version number as the `minrust` parameter to
 `azure/stages.yml`. If you wish to disable the MSRV check, set `minrust`
 to `false`.
 
+**This is not supported on `nightly-stages.yml`.**
+
 ### Coverage on Rust nightly
 
 ```yaml
@@ -49,6 +51,8 @@ that you cannot set a _specific_ nightly version, but are instead tied
 to the version that tarpaulin ships. For this reason, nightly coverage
 will always be run with failures allowed (yellow CI) to avoid spurious
 CI failures.
+
+**This is not supported on `nightly-stages.yml`.**
 
 ### Ignored tests
 
@@ -85,6 +89,8 @@ If you are working within a cargo workspace, you will have to pass
 features as `subcrate/feature` as described in [this
 issue](https://github.com/rust-lang/cargo/issues/5015). There is not
 currently a way to disabling default features for CI tests.
+
+**`nightly_feature is not supported (or needed) on `nightly-stages.yml`.**
 
 ### Single-threaded test execution
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -47,6 +47,12 @@ And now, to quote the French, [allons-y](https://www.lawlessfrench.com/expressio
    
    Where `PLACEHOLDER` is the service connection name from setup.
 
+## My project is nightly-only
+
+Great! Give `azure/nightly-stages.yml` a try. It takes mostly all the
+same [configuration parameters](configuration.md) as `stages.yml`, but
+runs everything only on nightly without allowing failures.
+
 ## My project is special
 
 The main template this repository provides, `azure/stages.yml`, is


### PR DESCRIPTION
Projects that only run on nightly have slightly different needs from those that run on stable + beta. In particular, they do _not_ run on stable + beta, and they want failures on nightly to still count as a CI failure. `stages.yml` cannot be configured that way, so we add a new `nigthly-stages.yml` that caters specifically to the needs of nightly-only projects.

Fixes #58.